### PR TITLE
Grapple improved

### DIFF
--- a/Assets/Player/Player Script/BeardAnimationController.cs
+++ b/Assets/Player/Player Script/BeardAnimationController.cs
@@ -19,15 +19,15 @@ public class BeardAnimationController : MonoBehaviour {
     private int trailingSegments = 0; // segments currently "active" but behind the player (so not actually active)
     private int maxSegments; // the current max length of the beard in segments
 
-    private Transform target;
-    private Vector3 beardPath;
-    private Vector3 beardOrigin;
+    private Vector2 target;
+    private Vector2 beardPath;
+    private Vector2 beardOrigin;
 
     private BeardState nextState = BeardState.IDLE; // which state to transition to next after the current one
 
 	// Use this for initialization
 	void Start () {
-        target = gameObject.transform;
+        target = gameObject.transform.position;
         // uses object pooling so we don't waste resources spawning and destroying beard segments
 		for(int i=0; i<HARDMAXSEGMENTS; i++)
         {
@@ -38,25 +38,25 @@ public class BeardAnimationController : MonoBehaviour {
         beardTip = Instantiate(beardTipPrefab);
 	}
 
-    public void WhipBeard(Transform targetTransform)
+    public void WhipBeard(Vector2 target)
     {
         if(PlayerState.CurrentBeardState != BeardState.IDLE) { return; }
         nextState = BeardState.RETRACTING;
-        ExtendBeard(targetTransform);
+        ExtendBeard(target);
     }
 
     public void GrappleBeard(Transform targetTransform)
     {
         if (PlayerState.CurrentBeardState != BeardState.IDLE) { return; }
         nextState = BeardState.PULLING;
-        ExtendBeard(targetTransform);
+        ExtendBeard(targetTransform.position);
     }
 
     // extend the beard out to a point
-    private void ExtendBeard(Transform targetTransform)
+    private void ExtendBeard(Vector2 target)
     {
-        target = targetTransform;
-        maxSegments = (int)((target.position - beardOrigin).magnitude / SEGMENTDISTANCE); // can't use beardPath here as it hasn't been updated yet
+        this.target = target;
+        maxSegments = (int)((target - beardOrigin).magnitude / SEGMENTDISTANCE); // can't use beardPath here as it hasn't been updated yet
         PlayerState.CurrentBeardState = BeardState.EXTENDING;
         beardTip.GetComponent<Collider2D>().enabled = true;
     }
@@ -64,7 +64,7 @@ public class BeardAnimationController : MonoBehaviour {
     private void FixedUpdate()
     {
         beardOrigin = transform.position;
-        beardPath = target.position - beardOrigin;
+        beardPath = target - beardOrigin;
         switch (PlayerState.CurrentBeardState)
         {
             case BeardState.EXTENDING:
@@ -108,7 +108,7 @@ public class BeardAnimationController : MonoBehaviour {
         for(int i=trailingSegments; i<visibleSegments; i++)
         {
             // if the segment is farther from the target than the player
-            if(beardPath.sqrMagnitude <= (segments[i].transform.position - beardOrigin).magnitude)
+            if(beardPath.sqrMagnitude <= (segments[i].transform.position - new Vector3(beardOrigin.x, beardOrigin.y, 0f)).magnitude)
             {
                 segments[i].SetActive(false);
                 trailingSegments++;

--- a/Assets/Player/Player Script/BeardAttacks.cs
+++ b/Assets/Player/Player Script/BeardAttacks.cs
@@ -48,6 +48,7 @@ public class BeardAttacks : MonoBehaviour {
         }
         else
         {
+            Debug.Log("LKSDFJHDSLKFJ");
             WhipBeard(particle);
         }
     }

--- a/Assets/Player/Player Script/BeardAttacks.cs
+++ b/Assets/Player/Player Script/BeardAttacks.cs
@@ -56,7 +56,7 @@ public class BeardAttacks : MonoBehaviour {
     // assuming the target is in range, not range-limited
     private void WhipBeard(GameObject targetObject)
     {
-        beardAnimator.WhipBeard(targetObject.transform);
+        beardAnimator.WhipBeard(targetObject.transform.position);
         Debug.Log("whip");
     }
 

--- a/Assets/Player/Player Script/BeardController.cs
+++ b/Assets/Player/Player Script/BeardController.cs
@@ -49,7 +49,7 @@ public class BeardController : MonoBehaviour
         // TODO: here I assume that all enemies/grappleable objects will have an associated component, we can change this later based on the actual components' names/different critereon
         if ((targetObject && targetObject.name == "Grapple Point") && !MovementController.Crouching())
         {
-            GrappleBeard(targetObject);
+            GrappleBeard(targetHit.point);
         }
         else
         {
@@ -61,15 +61,15 @@ public class BeardController : MonoBehaviour
     // assuming the target is in range, not range-limited
     private void WhipBeard(GameObject targetObject)
     {
-        beardAnimator.WhipBeard(targetObject.transform);
+        beardAnimator.WhipBeard(targetObject.transform.position);
         Debug.Log("whip");
     }
 
     // assuming the target is in range, not range-limited
-    private void GrappleBeard(GameObject grappleObject)
+    private void GrappleBeard(Vector2 target)
     {
-        beardAnimator.WhipBeard(grappleObject.transform);
-        var dir = (Vector2) grappleObject.transform.position- beardman.position;
+        beardAnimator.WhipBeard(target);
+        var dir = (Vector2) target- beardman.position;
 		    beardman.velocity = Vector2.zero;
         
         beardman.AddForce(new Vector2(dir.x, 0) * grappleForce, ForceMode2D.Impulse);

--- a/Assets/Player/Player Script/BeardController.cs
+++ b/Assets/Player/Player Script/BeardController.cs
@@ -43,11 +43,11 @@ public class BeardController : MonoBehaviour
     public void UseBeard()
     {
         Vector2 targetPosition = this.transform.position;
-        RaycastHit2D targetHit = Physics2D.Raycast(targetPosition, Vector2.zero);
+        RaycastHit2D targetHit = Physics2D.Linecast(transform.position, beardman.position);
         GameObject targetObject = targetHit ? targetHit.collider.gameObject : null;
 
         // TODO: here I assume that all enemies/grappleable objects will have an associated component, we can change this later based on the actual components' names/different critereon
-		if ((targetObject && targetObject.name == "Grapple Point") && !MovementController.Crouching())
+        if ((targetObject && targetObject.name == "Grapple Point") && !MovementController.Crouching())
         {
             GrappleBeard(targetObject);
         }


### PR DESCRIPTION
can now click past (not just on) a grapple point to grapple to it, also the grapple now affixes to the exact point of contact on the grapple object rather than just its origin, allowing us to have entire grapple walls/ceilings without many ugly discrete grapple points.  Wasn't able to replicate the grapple collision bug but will continue to keep an eye out for it.