### PR TITLE
Large changes made to how enemy units interact

### DIFF
--- a/Assets/Enemies/EnemyScripts/Movement/AnimalMovement.cs
+++ b/Assets/Enemies/EnemyScripts/Movement/AnimalMovement.cs
@@ -67,11 +67,11 @@ public class AnimalMovement : MonoBehaviour {
 	public void OnTriggerEnter2D(Collider2D collision) {
 		//Debug.Log ("Collider happened!");
 
-		/*if (collision.gameObject.CompareTag ("EnemyCollisionOnly") && !jumping) {
+		if (collision.gameObject.CompareTag ("EnemyCollisionOnly") && !jumping) {
 			movingRight = -movingRight;
 		    spriteRenderer.flipX = !spriteRenderer.flipX;
             //Debug.Log ("Switched direction!");
-		}*/
+		}
 
 		/*
 			double doIJump = Random.Range(0f, 1f);

--- a/Assets/Enemies/EnemyScripts/Movement/AnimalMovement.cs
+++ b/Assets/Enemies/EnemyScripts/Movement/AnimalMovement.cs
@@ -30,22 +30,48 @@ public class AnimalMovement : MonoBehaviour {
 	}
 	
 	// Update is called once per frame
-	void Update () {
+	void FixedUpdate () {
 		//Moves animal
 		if(!jumping) {
 			Vector2 vector = new Vector2 (speed * movingRight, 0f);
 			m_rigidbody.AddForce(vector);
 		}
-	}
+
+	    if (IsGroundToFront())
+	    {
+	        Debug.Log("close to some ground, let's turn around");
+	        movingRight = -movingRight;
+	        spriteRenderer.flipX = !spriteRenderer.flipX;
+        }
+
+    }
+
+    private bool IsGroundToFront()
+    {
+        // forward project a ray to check if there's ground or something
+        // turn around after hitting it
+        var vecDirection = Vector3.right * movingRight;
+        var mask = LayerMask.GetMask("Ground", "Default");
+
+        var colliderDirection = Physics2D.OverlapCircle(transform.position + vecDirection * 1.2f, 0.5f, mask);
+        //Debug.Log("What's in front of me: " + colliderDirection);
+        if (colliderDirection != null)
+        {
+            if(colliderDirection.gameObject.CompareTag("Untagged"))
+            return true;
+        }
+
+        return false;
+    }
 
 	public void OnTriggerEnter2D(Collider2D collision) {
 		//Debug.Log ("Collider happened!");
 
-		if (collision.gameObject.CompareTag ("EnemyCollisionOnly") && !jumping) {
+		/*if (collision.gameObject.CompareTag ("EnemyCollisionOnly") && !jumping) {
 			movingRight = -movingRight;
 		    spriteRenderer.flipX = !spriteRenderer.flipX;
             //Debug.Log ("Switched direction!");
-		}
+		}*/
 
 		/*
 			double doIJump = Random.Range(0f, 1f);
@@ -56,6 +82,42 @@ public class AnimalMovement : MonoBehaviour {
 			}
 		}*/
 	}
+
+    /**
+     * Enforce a direction change when an Enemy and Enemy interact, checking  for valid movement options
+     */
+    public void OnCollisionEnter2D(Collision2D collision)
+    {
+        var collidedObj = collision.gameObject;
+        if (collidedObj.CompareTag("Enemy"))
+        {
+            Debug.Log("Hit another enemy. My direction is " + movingRight);
+
+            // check if it is right next to an obstacle
+            var vecOppositeDirection = Vector3.right * (-1.0f) * movingRight;
+            var colliderOppositeDirection = Physics2D.Raycast(transform.position, vecOppositeDirection, 0.5f);
+            //var enemyColliderLeftCast = Physics2D.Raycast(transform.position, Vector3.left, 1.0f);
+
+            if (colliderOppositeDirection.collider.CompareTag("EnemyCollisionOnly"))
+            {
+                // keep our direction going away from it
+                Debug.Log("At a wall, moving away from it");
+            }
+            else
+            {
+                movingRight = -movingRight;
+                spriteRenderer.flipX = !spriteRenderer.flipX;
+                m_rigidbody.velocity = Vector2.right * movingRight * 2.0f;
+            }
+
+            return;
+        }
+        // change direction
+        //Debug.Log("Hit something");
+        //movingRight = -movingRight;
+        //spriteRenderer.flipX = !spriteRenderer.flipX;
+        
+    }
 
 	private IEnumerator jump() {
 		jumping = true;

--- a/Assets/Environment/EnvironmentScripts/MovementController.cs
+++ b/Assets/Environment/EnvironmentScripts/MovementController.cs
@@ -95,7 +95,7 @@ public class MovementController : MonoBehaviour {
 
         if( ( Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.A)) && IsGrounded)
         {
-            Debug.Log(footSource.isPlaying);
+            //Debug.Log(footSource.isPlaying);
             if (!footSource.isPlaying)
             {
                 footSource.Play();

--- a/Assets/Resources/Player/HealthPickUp.prefab
+++ b/Assets/Resources/Player/HealthPickUp.prefab
@@ -39,7 +39,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882846287612712}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 117.86001, y: -14.570521, z: -0.6524556}
+  m_LocalPosition: {x: 99.8548, y: -5.3672476, z: 0}
   m_LocalScale: {x: 0.021939376, y: 0.019913165, z: 1}
   m_Children: []
   m_Father: {fileID: 0}


### PR DESCRIPTION
Ground units that collide with grid-based obstacles and other enemies should change directions as expected. This was done with some checks that should prevent enemies from continuing to run into walls, and a slight velocity boost when enemies turn away from each other (to remedy existing edge cases)

Air units are still subject to EnemyCollider

Also moved code from Update to FixedUpdate for timescale assurances